### PR TITLE
update backtick to pipeline syntax per elm 0.18

### DIFF
--- a/src/articles/2016-11-02-elm-maybe.md
+++ b/src/articles/2016-11-02-elm-maybe.md
@@ -109,7 +109,7 @@ Maybe.oneOf [ Nothing, Nothing, Nothing ]
 And last but not least the higher order function `andThen` can be used to chain computations. It receives a `Maybe` value and a callback function that gets invoked in case there is a value:
 
 ```elm
-(List.head [3,4,5]) `andThen` (\n -> Just(n * 3))
+(List.head [3,4,5]) |> Maybe.andThen (\n -> Just(n * 3))
 -- Just 9 : Maybe.Maybe number
 ```
 


### PR DESCRIPTION
backticks went away in elm 0.18 in favor of pipelining, this updates the
syntax in the "maybe" post to reflect that change.

elm 0.18 migration guide: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md