### PR TITLE
Changed the order of server archive installs

### DIFF
--- a/src/articles/2016-12-30-phoenix-deployment-gatling-ubuntu-digital-ocean.md
+++ b/src/articles/2016-12-30-phoenix-deployment-gatling-ubuntu-digital-ocean.md
@@ -271,9 +271,9 @@ To do so, log in as the `deploy` user on the production server and execute these
 [install Gatling](https://github.com/hashrocket/gatling#instructions):
 
 ```bash
-mix archive.install https://github.com/hashrocket/gatling_archives/raw/master/gatling.ez
 mix local.hex
 mix local.rebar
+mix archive.install https://github.com/hashrocket/gatling_archives/raw/master/gatling.ez
 ```
 
 Afterwards we can initialize the app using the `load` task provided by Gatling.


### PR DESCRIPTION
When I tried the current order I got a message, `No archives currently installed.` Installing hex first fixed it.